### PR TITLE
Import optimizations

### DIFF
--- a/operations/gobierto_people/check-data-presence/run.rb
+++ b/operations/gobierto_people/check-data-presence/run.rb
@@ -15,9 +15,10 @@ require_relative "../../../utils/local_storage"
 # Arguments:
 #  - 0: Rails env
 #  - 1: Dataset. Required. Options events, gifts, invitations or all
-#  - 2: Start Date. Optional. If blank the start date will use the last
+#  - 2: Start Date. Optional. If value is "forever", data of any time
+#       is requested. If blank the start date will use the last
 #       execution date if existed
-#  - 3: End Date. Optional
+#  - 3: End Date. Optional. Ignored if previous argument is "forever"
 #
 # Samples:
 #
@@ -37,12 +38,16 @@ end
 
 rails_env = ARGV[0]
 datasets = ARGV[1] == "all" ? valid_datasets : [ARGV[1].to_sym]
-start_date = ARGV[2] ? DateTime.parse(ARGV[2]) : nil
-end_date = ARGV[3] ? DateTime.parse(ARGV[3]) : nil
 
-last_execution = Utils::LocalStorage.new(path: "downloads/last_start_query_date-#{rails_env}.txt")
-if start_date.blank? && last_execution.exist?
-  start_date = DateTime.parse(last_execution.content)
+start_date = end_date = nil
+unless ARGV[2] == "forever"
+  start_date = DateTime.parse(ARGV[2]) if ARGV[2]
+  end_date = DateTime.parse(ARGV[3]) if ARGV[3]
+
+  last_execution = Utils::LocalStorage.new(path: "downloads/last_start_query_date-#{rails_env}.txt")
+  if start_date.blank? && last_execution.exist?
+    start_date = DateTime.parse(last_execution.content)
+  end
 end
 
 puts "[START] check-data-presence/run.rb with datasets=#{ datasets.join(", ") }, start_date=#{ start_date }, end_date=#{ end_date }"

--- a/operations/gobierto_people/clear-previous-data/run.rb
+++ b/operations/gobierto_people/clear-previous-data/run.rb
@@ -1,0 +1,43 @@
+#!/usr/bin/env ruby
+
+require "bundler/setup"
+Bundler.require
+
+# Usage:
+#
+#  - Must be ran as a gobierto runner.
+#
+# Arguments:
+#  - 1: Domain of site where the people data has to be removed
+#
+# Samples:
+#
+#   /path/to/project/operations/gobierto_people/clear-previous-data/run.rb gencat.gobierto.test
+#
+
+if ARGV.length != 1
+  raise "Incorrect number of arguments. Execute run.rb domain"
+end
+
+site = Site.find_by_domain ARGV[0]
+
+puts "[START] clear-previous-data/run.rb with domain=#{ site.domain }"
+
+if site.present?
+  site.events.with_deleted.each do |event|
+    event.really_destroy!
+  end
+  site.people.destroy_all
+  site.gifts.destroy_all
+  site.invitations.destroy_all
+  site.trips.destroy_all
+  site.departments.destroy_all
+  site.interest_groups.destroy_all
+  site.collections.where(container_type: "GobiertoPeople::Person").destroy_all
+  site.collection_items.where(item_type: "GobiertoCalendars::Event").destroy_all
+else
+  puts "Site not found. Nothing to do"
+end
+
+puts "[END] clear-previous-data/run.rb"
+exit 0

--- a/pipelines/import_agendas/Jenkinsfile
+++ b/pipelines/import_agendas/Jenkinsfile
@@ -19,17 +19,21 @@ pipeline {
         }
         stage('Extract > Clear previous data') {
             steps {
-                if (${CLEAR_PREVIOUS_DATA}=='true') {
-                    sh "cd ${GENCAT_ETL}; ruby operations/gobierto_people/clear-previous-data/run.rb ${GENCAT_SITE_DOMAIN}"
+                script {
+                    if (${CLEAR_PREVIOUS_DATA}=='true') {
+                        sh "cd ${GENCAT_ETL}; ruby operations/gobierto_people/clear-previous-data/run.rb ${GENCAT_SITE_DOMAIN}"
+                    }
                 }
             }
         }
         stage('Extract > Check data presence') {
             steps {
-                if (${CLEAR_PREVIOUS_DATA}=='true') {
-                    sh "cd ${GENCAT_ETL}; ruby operations/gobierto_people/check-data-presence/run.rb ${RAILS_ENV} all forever"
-                } else {
-                    sh "cd ${GENCAT_ETL}; ruby operations/gobierto_people/check-data-presence/run.rb ${RAILS_ENV} all"
+                script {
+                    if (${CLEAR_PREVIOUS_DATA}=='true') {
+                        sh "cd ${GENCAT_ETL}; ruby operations/gobierto_people/check-data-presence/run.rb ${RAILS_ENV} all forever"
+                    } else {
+                        sh "cd ${GENCAT_ETL}; ruby operations/gobierto_people/check-data-presence/run.rb ${RAILS_ENV} all"
+                    }
                 }
             }
         }

--- a/pipelines/import_agendas/Jenkinsfile
+++ b/pipelines/import_agendas/Jenkinsfile
@@ -9,6 +9,7 @@ pipeline {
         // GOBIERTO = "/var/www/gobierto/currentt"
         // GENCAT_SITE_DOMAIN = "gencat.gobierto.es"
         // RAILS_ENV = "production"
+        // CLEAR_PREVIOUS_DATA = false
     }
     stages {
         stage('Extract > Download last start query date') {
@@ -16,9 +17,20 @@ pipeline {
                 sh "cd ${GOBIERTO_ETL_UTILS}; ruby operations/download-s3/run.rb 'gencat/gobierto_people/last_execution/last_start_query_date-${RAILS_ENV}.txt' /tmp/gencat/downloads"
             }
         }
+        stage('Extract > Clear previous data') {
+            steps {
+                if (${CLEAR_PREVIOUS_DATA}=='true') {
+                    sh "cd ${GENCAT_ETL}; ruby operations/gobierto_people/clear-previous-data/run.rb ${GENCAT_SITE_DOMAIN}"
+                }
+            }
+        }
         stage('Extract > Check data presence') {
             steps {
-                sh "cd ${GENCAT_ETL}; ruby operations/gobierto_people/check-data-presence/run.rb ${RAILS_ENV} all"
+                if (${CLEAR_PREVIOUS_DATA}=='true') {
+                    sh "cd ${GENCAT_ETL}; ruby operations/gobierto_people/check-data-presence/run.rb ${RAILS_ENV} all forever"
+                } else {
+                    sh "cd ${GENCAT_ETL}; ruby operations/gobierto_people/check-data-presence/run.rb ${RAILS_ENV} all"
+                }
             }
         }
         stage('Extract > Clean previous downloads') {

--- a/pipelines/import_agendas/Jenkinsfile
+++ b/pipelines/import_agendas/Jenkinsfile
@@ -18,23 +18,21 @@ pipeline {
             }
         }
         stage('Extract > Clear previous data') {
+            when { expression { env.CLEAR_PREVIOUS_DATA == 'true' } }
             steps {
-                script {
-                    if (${CLEAR_PREVIOUS_DATA}=='true') {
-                        sh "cd ${GENCAT_ETL}; ruby operations/gobierto_people/clear-previous-data/run.rb ${GENCAT_SITE_DOMAIN}"
-                    }
-                }
+                sh "cd ${GOBIERTO}; bin/rails runner ${GENCAT_ETL}/operations/gobierto_people/clear-previous-data/run.rb ${GENCAT_SITE_DOMAIN}"
             }
         }
-        stage('Extract > Check data presence') {
+        stage('Extract > Check data presence of any time') {
+            when { expression { env.CLEAR_PREVIOUS_DATA == 'true' } }
             steps {
-                script {
-                    if (${CLEAR_PREVIOUS_DATA}=='true') {
-                        sh "cd ${GENCAT_ETL}; ruby operations/gobierto_people/check-data-presence/run.rb ${RAILS_ENV} all forever"
-                    } else {
-                        sh "cd ${GENCAT_ETL}; ruby operations/gobierto_people/check-data-presence/run.rb ${RAILS_ENV} all"
-                    }
-                }
+                sh "cd ${GENCAT_ETL}; ruby operations/gobierto_people/check-data-presence/run.rb ${RAILS_ENV} all forever"
+            }
+        }
+        stage('Extract > Check data presence since last build') {
+            when { expression { env.CLEAR_PREVIOUS_DATA != 'true' } }
+            steps {
+                sh "cd ${GENCAT_ETL}; ruby operations/gobierto_people/check-data-presence/run.rb ${RAILS_ENV} all"
             }
         }
         stage('Extract > Clean previous downloads') {

--- a/pipelines/import_agendas/dev_run.sh
+++ b/pipelines/import_agendas/dev_run.sh
@@ -1,14 +1,24 @@
 #!/bin/bash
 
-GENCAT_SITE_DOMAIN="madrid.gobierto.test"
+GENCAT_SITE_DOMAIN="gencat.gobierto.test"
+CLEAR_PREVIOUS_DATA=true
 RAILS_ENV="development"
 
 # Extract > Download last start query date
 cd $DEV_DIR/gobierto-etl-utils/; ruby operations/download-s3/run.rb "gencat/gobierto_people/last_execution/last_start_query_date-$RAILS_ENV.txt" /tmp/gencat/downloads/
 
 # cd $DEV_DIR/gobierto-etl-gencat/; ruby operations/gobierto_people/clear-path/run.rb downloads/last_start_query_date-$RAILS_ENV.txt
-# Extract > Check data presence
-cd $DEV_DIR/gobierto-etl-gencat/; ruby operations/gobierto_people/check-data-presence/run.rb $RAILS_ENV all
+# Extract > Clear previous data
+if $CLEAR_PREVIOUS_DATA; then
+  cd $DEV_DIR/gobierto/; bin/rails runner $DEV_DIR/gobierto-etl-gencat/operations/gobierto_people/clear-previous-data/run.rb $GENCAT_SITE_DOMAIN
+fi
+
+# # Extract > Check data presence
+if $CLEAR_PREVIOUS_DATA; then
+  cd $DEV_DIR/gobierto-etl-gencat/; ruby operations/gobierto_people/check-data-presence/run.rb $RAILS_ENV all forever
+else
+  cd $DEV_DIR/gobierto-etl-gencat/; ruby operations/gobierto_people/check-data-presence/run.rb $RAILS_ENV all
+fi
 
 # Extract > Clean previous downloads
 cd $DEV_DIR/gobierto-etl-gencat/; ruby operations/gobierto_people/clear-path/run.rb downloads/datasets

--- a/utils/events_importer.rb
+++ b/utils/events_importer.rb
@@ -38,6 +38,7 @@ module Utils
                          title_translations: { "ca" => row.cleaned_text("tema") },
                          site_id: @site.id,
                          person_id: person.id,
+                         slug: row[":id"],
                          meta: { "type" => row.cleaned_text("activitat") },
                          state: GobiertoCalendars::Event.states[:published],
                          department_id: department.id,

--- a/utils/people_importer.rb
+++ b/utils/people_importer.rb
@@ -56,7 +56,7 @@ module Utils
         matching_people = dictionary[person.name].map { |name| @site.people.find_by_name(name) }.compact
         if matching_people.present?
           if person.new_record?
-            person_attrs = person.attributes.except("id", "created_at", "updated_at")
+            person_attrs = person.attributes.except("id", "created_at", "updated_at", "slug", "position")
             person = matching_people.shift
             person.update(person_attrs)
           end


### PR DESCRIPTION
This PR:
* Adds an operation to clear people data of a site
* Refactors check-data-presence to get all available records from datasets
* Makes use of a `CLEAR_PREVIOUS_DATA` environment variable to run different pipelines:
  * With `CLEAR_PREVIOUS_DATA` as false the pipeline imports data created since the last import
  * With `CLEAR_PREVIOUS_DATA` as true the pipeline deletes all people data from site and reimport all the available data
