### PR TITLE
Various fixes

### DIFF
--- a/utils/events_importer.rb
+++ b/utils/events_importer.rb
@@ -29,7 +29,7 @@ module Utils
         )
         not_persisted_resources = [person, department, interest_group].select { |resource| resource.new_record? }
         if not_persisted_resources.blank?
-          start_date = row.datetime("data")
+          start_date = row.datetime("data") || row.datetime(":created_at") # If data (date) is nil, use the created_at attribute
           start_date = start_date.change(year: row.datetime(":created_at").year) if start_date.year < 2010
           end_date = 1.hour.since(start_date)
           attributes = { external_id: row[":id"],

--- a/utils/events_importer.rb
+++ b/utils/events_importer.rb
@@ -70,7 +70,7 @@ module Utils
         end
         puts "===================================="
       rescue StandardError => e
-        Rollbar.error(e)
+        Rollbar.error(e, "Error processing row with external_id: #{ row[":id"] }")
       end
 
       super

--- a/utils/row_decorator.rb
+++ b/utils/row_decorator.rb
@@ -31,7 +31,6 @@ module Utils
         end.compact
       }
     rescue StandardError => e
-      Rollbar.error("Error parsing trip location: #{location_name} - #{e}")
       { "destinations" => [] }
     end
 


### PR DESCRIPTION
This PR:

- [ ] Removes a Rollbar notification on parsing cities (this was more an alert that was being logged than a Rollbar), related with https://github.com/PopulateTools/gobierto-etl-gencat/commit/818bdfeaa0da4a031d80c5141cc6c4851fcb3edf

- [ ] When parsing an event fails, the Rollbar includes the external id of the event for debugging

- [ ] There's a fallback date for events in case date is missing, as in previous code