### PR TITLE
Use different endpoints depending on the environment

### DIFF
--- a/operations/gobierto_people/check-data-presence/run.rb
+++ b/operations/gobierto_people/check-data-presence/run.rb
@@ -25,18 +25,19 @@ require_relative "../../../utils/local_storage"
 #   /path/to/project/operations/gobierto_people/check-data-presence/run.rb staging gifts 2018-06-01 2018-07-01
 #
 
-valid_datasets = Utils::OriginDataset.valid_datasets
-dataset_opts = valid_datasets + [:all]
 
 if ARGV.length < 2
   raise "Rails env and dataset argument are required. Options: #{ dataset_opts.join("|") }"
 end
 
+rails_env = ARGV[0]
+valid_datasets = Utils::OriginDataset.valid_datasets(rails_env)
+dataset_opts = valid_datasets + [:all]
+
 if !dataset_opts.include? ARGV[1].to_sym
   raise "Invalid dataset argument. Options: #{ dataset_opts.join("|") }"
 end
 
-rails_env = ARGV[0]
 datasets = ARGV[1] == "all" ? valid_datasets : [ARGV[1].to_sym]
 
 start_date = end_date = nil
@@ -55,7 +56,7 @@ puts "[START] check-data-presence/run.rb with datasets=#{ datasets.join(", ") },
 datasets_for_extraction = []
 datasets.each do |dataset|
   puts "Checking #{ dataset } records presence..."
-  dataset_query = Utils::OriginDataset.new(start_date: start_date, end_date: end_date, dataset: dataset)
+  dataset_query = Utils::OriginDataset.new(start_date: start_date, end_date: end_date, dataset: dataset, environment: rails_env)
   if (count = dataset_query.data_count) == 0
     if start_date.blank?
       puts "The dataset of #{ dataset } doesn't have any data"

--- a/utils/origin_dataset.rb
+++ b/utils/origin_dataset.rb
@@ -5,21 +5,42 @@ require "openssl"
 
 module Utils
   class OriginDataset
-    DATASET_IDS = { events: "4npk-u4e8",
-                    gifts: "t4qw-gx3q",
-                    invitations: "na9g-qaxb",
-                    trips: "4ngp-d7x6" }
+    DATASET_IDS = {
+      "development" => {
+        events: "pada-92wh",
+        gifts: "amh6-6pgd",
+        invitations: "pxgs-vhxp",
+        trips: "dze7-9jyh",
+        charges: "ebap-zcun"
+      },
+      "staging" => {
+        events: "pada-92wh",
+        gifts: "amh6-6pgd",
+        invitations: "pxgs-vhxp",
+        trips: "dze7-9jyh",
+        charges: "ebap-zcun"
+      },
+      "production" => {
+        events: "4npk-u4e8",
+        gifts: "t4qw-gx3q",
+        invitations: "na9g-qaxb",
+        trips: "4ngp-d7x6"
+      }
+    }
     URL = "https://analisi.transparenciacatalunya.cat/resource"
+    TEST_URL = "https://ctti.azure-westeurope-prod.socrata.com/resource"
 
-    def self.valid_datasets
-      DATASET_IDS.keys
+    def self.valid_datasets(environment)
+      DATASET_IDS[environment].keys
     end
 
     def initialize(opts={})
       @start_date = opts[:start_date]
       @end_date = opts[:end_date]
       @dataset = opts[:dataset]
-      @dataset_id = DATASET_IDS[opts[:dataset]]
+      @environment = opts[:environment].to_s
+      @dataset_id = DATASET_IDS[@environment][opts[:dataset]]
+      @url = @environment == "production" ? URL : TEST_URL
     end
 
     def date_interval_condition
@@ -40,6 +61,8 @@ module Utils
         "$order=data_inici ASC"
       elsif @dataset == :trips
         "$order=Id ASC"
+      elsif @dataset == :charges
+        nil
       else
         raise StandardError, "Unknown sort condition for this dataset"
       end
@@ -54,7 +77,7 @@ module Utils
     end
 
     def query_url(conditions, format="csv")
-      URI.encode("#{ URL }/#{ @dataset_id }.#{ format }?#{ conditions.compact.join("&") }")
+      URI.encode("#{ @url }/#{ @dataset_id }.#{ format }?#{ conditions.compact.join("&") }")
     end
 
     def data_count


### PR DESCRIPTION
This PR allows to define different endpoints to import datasets depending on the environment.

The datasets ids and the path to download the datasets are defined for `development`, `staging` and `production`. 

Nothing should change in production after merging this PR, the changes have been made to modify staging requests.