### PR TITLE
Improve performance

### DIFF
--- a/utils/base_importer.rb
+++ b/utils/base_importer.rb
@@ -36,7 +36,12 @@ module Utils
         end
       else
         puts "The importer has loaded data with no errors"
+        puts @extra_info
       end
+    end
+
+    def data_count
+      @data.count
     end
 
     def errors?

--- a/utils/charges_importer.rb
+++ b/utils/charges_importer.rb
@@ -34,7 +34,7 @@ module Utils
         not_persisted_resources = [person, department].select { |resource| resource.new_record? }
         if not_persisted_resources.blank?
           @charge_importer.import!(
-            attributes: { external_id: row[id_key] },
+            attributes: { external_id: row[id_key].presence || row["id"] },
             extra: { person_id: person.id,
                      department_id: department.id,
                      name: row.cleaned_text("desc_carrec"),

--- a/utils/events_importer.rb
+++ b/utils/events_importer.rb
@@ -3,6 +3,7 @@ require_relative "./base_importer"
 module Utils
   class EventsImporter < BaseImporter
     def import!
+      events_count = @data.count
       @data.each do |row|
         puts "\n\n===================================="
         puts "Processing Row... #{ row.pretty_inspect }\n\n"
@@ -65,6 +66,8 @@ module Utils
       rescue StandardError => e
         Rollbar.error(e, "Error processing row with external_id: #{ row[":id"] }")
       end
+
+        @extra_info = "There was #{data_count} events to import and currently there are #{@site.events.count}. #{data_count > @site.events.count ? "Something is wrong, there are more events to import than existing ones" : "Counts are OK"}"
 
       super
     end

--- a/utils/people_importer.rb
+++ b/utils/people_importer.rb
@@ -96,7 +96,7 @@ module Utils
 
       if matching_people.exists?
         matching_person = matching_people.first
-        puts "Found existing person #{ matching_person.name }"
+        puts "Found existing person with name #{ matching_person.name } and slug #{ matching_person.slug }"
 
         if proper_name.extends? Utils::ProperName.new(matching_person.name)
           old_name = matching_person.name
@@ -106,6 +106,7 @@ module Utils
         end
         matching_person
       else
+        puts "Initialized new person with name #{proper_name.name} and slug #{proper_name.slug}"
         @site.people.active.new(name: proper_name.name, slug: proper_name.slug)
       end
     end

--- a/utils/people_importer.rb
+++ b/utils/people_importer.rb
@@ -12,6 +12,7 @@ module Utils
     def initialize(opts = {})
       @similarities_with_existing_people = {}
       @site = opts[:site]
+      @existing_people = {}
       @errors = []
     end
 
@@ -29,9 +30,11 @@ module Utils
 
     def resolve_name_similarities(name)
       proper_name = Utils::ProperName.new(name)
-      automatic_matches = @site.people.where("slug ~* ? OR name = ?", proper_name.slug_regexp, proper_name.name)
+      automatic_matches = find_existing_person(proper_name)
+      return proper_name.name if automatic_matches.exists? || dictionary.has_key?(proper_name.name)
+
       matches = find_similarities(proper_name)
-      return proper_name.name if automatic_matches.exists? || matches.blank? || dictionary.has_key?(proper_name.name)
+      return proper_name.name if matches.blank?
 
       if (name_solution = matches.find { |match| dictionary.has_key?(match.name) })
         puts "Name #{ proper_name.name } resolved as #{ name_solution.name }"
@@ -76,6 +79,7 @@ module Utils
     def save_new(person)
       if (result = person.save)
         puts "Created person: #{ person.pretty_inspect }"
+        add_to_existing_people(person)
       else
         error = { resource_attrs: person.pretty_inspect,
                   errors_msg: person.errors.full_messages.pretty_inspect }
@@ -86,15 +90,29 @@ module Utils
       result
     end
 
+    def add_to_existing_people(person)
+      (@existing_people[{ name: person.name, slug: person.slug }] ||= []).append(person)
+    end
+
+    def find_existing_person(proper_name)
+      cached_result = @existing_people.find do |key, _|
+        proper_name.slug_regexp.match?(key[:slug]) || proper_name == key[:name]
+      end&.last
+
+      return cached_result if cached_result.present?
+
+      @existing_people[{ name: proper_name.name, slug: proper_name.slug }] = @site.people.where("slug ~* ? OR name = ?", proper_name.slug_regexp_string, proper_name.name).to_a
+    end
+
     def inspect_person(person)
       person.attributes.extract!("id", "name", "slug").pretty_inspect
     end
 
     def find_or_initialize_person(name)
       proper_name = Utils::ProperName.new(name)
-      matching_people = @site.people.where("slug ~* ? OR name = ?", proper_name.slug_regexp, proper_name.name)
+      matching_people = find_existing_person(proper_name)
 
-      if matching_people.exists?
+      if matching_people.present?
         matching_person = matching_people.first
         puts "Found existing person with name #{ matching_person.name } and slug #{ matching_person.slug }"
 

--- a/utils/proper_name.rb
+++ b/utils/proper_name.rb
@@ -12,7 +12,7 @@ module Utils
     end
 
     def extends?(other_name)
-      /#{ other_name.slug_regexp }/.match(slug) &&
+      other_name.slug_regexp.match?(slug) &&
         (components_without_conjunctions - other_name.components_without_conjunctions).join.length > (other_name.components_without_conjunctions - components_without_conjunctions).join.length
     end
 
@@ -20,7 +20,7 @@ module Utils
       @components - CONJUNCTIONS
     end
 
-    def slug_regexp
+    def slug_regexp_string
       parameterized_components = components.dup
       parameterized_components.map! do |component|
         if CONJUNCTIONS.include?(component)
@@ -38,6 +38,10 @@ module Utils
       end
 
       "^#{ parameterized_components.join("-").gsub(/-\(-/, "(-") }$"
+    end
+
+    def slug_regexp
+      Regexp.new(slug_regexp_string, true)
     end
 
     def abbrev_expr(string)


### PR DESCRIPTION
This PR changes importers to store created resources in a data structure and check existence of them inspecting it instead of making a request to database. With this it's expected to improve ETL perfomance by saving requests to database.

The PR also:

* Adds some more info to logs
* Updates and old failing dataset column name and checks the old and the new name