### PR TITLE
Use https in request to avoid 301 response

### DIFF
--- a/pipelines/import_custom_layout/Jenkinsfile
+++ b/pipelines/import_custom_layout/Jenkinsfile
@@ -5,7 +5,7 @@ pipeline {
         PATH = "$HOME/.rbenv/shims:$PATH"
         GENCAT_ETL = "/var/www/gobierto-etl-gencat/current"
         STORAGE_DIR = "/var/lib/jenkins/jobs/gobierto-etl-gencat\\ layout/builds/${env.BUILD_NUMBER}"
-        LAYOUT_LOCATION = "http://governobert.gencat.cat/templates?mode=html&code=GOOB0001"
+        LAYOUT_LOCATION = "https://governobert.gencat.cat/templates?mode=html&code=GOOB0001"
         LOCALES = "ca es"
         // Variables that must be defined via Jenkins UI:
         // GOBIERTO = "/var/www/gobierto/current"

--- a/pipelines/import_custom_layout/dev_run.sh
+++ b/pipelines/import_custom_layout/dev_run.sh
@@ -3,7 +3,7 @@
 set -e
 
 GENCAT_SITE_DOMAIN="madrid.gobierto.test"
-LAYOUT_LOCATION="http://governobert.gencat.cat/templates?mode=html&code=GOOB0001"
+LAYOUT_LOCATION="https://governobert.gencat.cat/templates?mode=html&code=GOOB0001"
 GENCAT_ETL=$DEV_DIR/gobierto-etl-gencat
 STORAGE_DIR=$DEV_DIR/gobierto-etl-gencat/tmp
 LOCALES="ca es"


### PR DESCRIPTION
closes  PopulateTools/issues#1356

The requests to url with http returns a 301 and redirects to https. This generates a blank response and an error 