### PR TITLE
Add step to skip people without ALT CARREC in tipologia column

### DIFF
--- a/utils/charges_importer.rb
+++ b/utils/charges_importer.rb
@@ -20,6 +20,12 @@ module Utils
       @data.each do |row|
         puts "\n\n===================================="
         puts "Processing Row... #{ row.pretty_inspect }\n\n"
+
+        unless row.cleaned_text("tipologia") == "ALT CARREC"
+          puts "Skipping not \"ALT CARREC\" person..."
+
+          next
+        end
         person = @people_importer.import!(
           attributes: {
             name: row.cleaned_text("nom_complert")

--- a/utils/events_importer.rb
+++ b/utils/events_importer.rb
@@ -7,6 +7,12 @@ module Utils
       @data.each do |row|
         puts "\n\n===================================="
         puts "Processing Row... #{ row.pretty_inspect }\n\n"
+
+        unless row.cleaned_text("tipologia") == "ALT CARREC"
+          puts "Skipping not \"ALT CARREC\" person..."
+
+          next
+        end
         person = @people_importer.import!(
           attributes: {
             name: row.cleaned_text("alt_c_rrec")

--- a/utils/events_importer.rb
+++ b/utils/events_importer.rb
@@ -15,7 +15,7 @@ module Utils
         end
         person = @people_importer.import!(
           attributes: {
-            name: row.cleaned_text("alt_c_rrec")
+            name: row.cleaned_text("nom_i_cognoms")
           }
         )
         interest_group = @interest_group_importer.import!(

--- a/utils/gifts_importer.rb
+++ b/utils/gifts_importer.rb
@@ -15,6 +15,12 @@ module Utils
       @data.each do |row|
         puts "\n\n===================================="
         puts "Processing Row... #{ row.pretty_inspect }\n\n"
+
+        unless row.cleaned_text("tipologia") == "ALT CARREC"
+          puts "Skipping not \"ALT CARREC\" person..."
+
+          next
+        end
         person = @people_importer.import!(
           attributes: {
             name: row.cleaned_text("rebut_per")

--- a/utils/invitations_importer.rb
+++ b/utils/invitations_importer.rb
@@ -15,6 +15,12 @@ module Utils
       @data.each do |row|
         puts "\n\n===================================="
         puts "Processing Row... #{ row.pretty_inspect }\n\n"
+
+        unless row.cleaned_text("tipologia") == "ALT CARREC"
+          puts "Skipping not \"ALT CARREC\" person..."
+
+          next
+        end
         person = @people_importer.import!(
           attributes: {
             name: row.cleaned_text("assisteix")

--- a/utils/origin_dataset.rb
+++ b/utils/origin_dataset.rb
@@ -16,7 +16,7 @@ module Utils
       "staging" => {
         events: "pada-92wh",
         gifts: "amh6-6pgd",
-        invitations: "pxgs-vhxp",
+        invitations: "2u63-j8pw",
         trips: "dze7-9jyh",
         charges: "t93n-tvdf"
       },


### PR DESCRIPTION
Recover of #116 which merge was reverted

This PR skips creation of people and charge when the new dataset column `tipologia` has a value other than `ALT CARREC`