### PR TITLE
Use clear-cache operation including site and namespace

### DIFF
--- a/pipelines/import_agendas/Jenkinsfile
+++ b/pipelines/import_agendas/Jenkinsfile
@@ -85,11 +85,6 @@ pipeline {
                 sh "cd ${GOBIERTO_ETL_UTILS}; ruby operations/upload-s3/run.rb /tmp/gencat/output/start_query_date.txt 'gencat/gobierto_people/last_execution/last_start_query_date-${RAILS_ENV}.txt'"
             }
         }
-        stage('Clear cache') {
-            steps {
-                sh "cd ${GOBIERTO}; bin/rails runner ${GOBIERTO_ETL_UTILS}/operations/gobierto/clear-cache/run.rb --site-domain '${GENCAT_SITE_DOMAIN}' --namespace 'GobiertoData'"
-            }
-        }
     }
     post {
         failure {

--- a/pipelines/import_agendas/Jenkinsfile
+++ b/pipelines/import_agendas/Jenkinsfile
@@ -87,7 +87,7 @@ pipeline {
         }
         stage('Clear cache') {
             steps {
-                sh "cd ${GOBIERTO}; bin/rails runner ${GOBIERTO_ETL_UTILS}/operations/gobierto/clear-cache/run.rb"
+                sh "cd ${GOBIERTO}; bin/rails runner ${GOBIERTO_ETL_UTILS}/operations/gobierto/clear-cache/run.rb --site-domain '${GENCAT_SITE_DOMAIN}' --namespace 'GobiertoData'"
             }
         }
     }

--- a/pipelines/import_agendas/dev_run.sh
+++ b/pipelines/import_agendas/dev_run.sh
@@ -47,6 +47,3 @@ cd $DEV_DIR/gobierto-etl-utils/; ruby operations/upload-s3/run.rb $WORKING_DIR/g
 
 # Documentation > Upload last execution date
 cd $DEV_DIR/gobierto-etl-utils/; ruby operations/upload-s3/run.rb /tmp/gencat/output/start_query_date.txt "gencat/gobierto_people/last_execution/last_start_query_date-$RAILS_ENV.txt"
-
-# Clear cache
-cd $DEV_DIR/gobierto/; bin/rails runner $DEV_DIR/gobierto-etl-utils/operations/gobierto/clear-cache/run.rb --site-domain "$GENCAT_SITE_DOMAIN" --namespace "GobiertoData"

--- a/pipelines/import_agendas/dev_run.sh
+++ b/pipelines/import_agendas/dev_run.sh
@@ -49,4 +49,4 @@ cd $DEV_DIR/gobierto-etl-utils/; ruby operations/upload-s3/run.rb $WORKING_DIR/g
 cd $DEV_DIR/gobierto-etl-utils/; ruby operations/upload-s3/run.rb /tmp/gencat/output/start_query_date.txt "gencat/gobierto_people/last_execution/last_start_query_date-$RAILS_ENV.txt"
 
 # Clear cache
-cd $DEV_DIR/gobierto-etl-utils/; ruby operations/gobierto/clear-cache/run.rb
+cd $DEV_DIR/gobierto/; bin/rails runner $DEV_DIR/gobierto-etl-utils/operations/gobierto/clear-cache/run.rb --site-domain "$GENCAT_SITE_DOMAIN" --namespace "GobiertoData"


### PR DESCRIPTION
Related to PopulateTools/issues#1439

This PR replaces the clear-cache operation call and includes site and namespace arguments

The cache-clear operation is required because the trips dataset is loaded in GobiertoData