### PR TITLE
Add clear cache step to agendas pipeline

### DIFF
--- a/pipelines/import_agendas/Jenkinsfile
+++ b/pipelines/import_agendas/Jenkinsfile
@@ -85,6 +85,11 @@ pipeline {
                 sh "cd ${GOBIERTO_ETL_UTILS}; ruby operations/upload-s3/run.rb /tmp/gencat/output/start_query_date.txt 'gencat/gobierto_people/last_execution/last_start_query_date-${RAILS_ENV}.txt'"
             }
         }
+        stage('Clear cache') {
+            steps {
+                sh "cd ${GOBIERTO}; bin/rails runner ${GOBIERTO_ETL_UTILS}/operations/gobierto/clear-cache/run.rb --site-domain '${GENCAT_SITE_DOMAIN}' --namespace 'GobiertoPeople'"
+            }
+        }
     }
     post {
         failure {

--- a/pipelines/import_agendas/dev_run.sh
+++ b/pipelines/import_agendas/dev_run.sh
@@ -47,3 +47,6 @@ cd $DEV_DIR/gobierto-etl-utils/; ruby operations/upload-s3/run.rb $WORKING_DIR/g
 
 # Documentation > Upload last execution date
 cd $DEV_DIR/gobierto-etl-utils/; ruby operations/upload-s3/run.rb /tmp/gencat/output/start_query_date.txt "gencat/gobierto_people/last_execution/last_start_query_date-$RAILS_ENV.txt"
+
+# Clear cache
+cd $DEV_DIR/gobierto; bin/rails runner $DEV_DIR/gobierto-etl-utils/operations/gobierto/clear-cache/run.rb --site-domain "$GENCAT_SITE_DOMAIN" --namespace "GobiertoPeople"


### PR DESCRIPTION
Related to PopulateTools/issues#1532

This PR adds a step to clear cached data of GobiertoPeople module for Gencat sites after loading data