### PR TITLE
Fix conjunctions resolution

### DIFF
--- a/utils/people_importer.rb
+++ b/utils/people_importer.rb
@@ -20,12 +20,21 @@ module Utils
       puts "\n\n===================================="
       puts     "=========== Import Person ==========="
       puts "Processing #{ attributes.values.join(", ") }...\n\n"
-      # name = resolve_name_similarities(attributes[:name])
-      person = find_or_initialize_person(attributes[:name])
+      name = resolve_name_ignoring_conjunctions(attributes[:name])
+      person = find_or_initialize_person(name)
         # person = merge_duplicates(person)
       save_new(person) if person.new_record?
       puts "====================================="
       person
+    end
+
+    def resolve_name_ignoring_conjunctions(name)
+      proper_name = Utils::ProperName.new(name)
+      automatic_match = find_existing_person(proper_name)&.first
+
+      return name unless automatic_match.present?
+
+      automatic_match.name
     end
 
     def resolve_name_similarities(name)

--- a/utils/proper_name.rb
+++ b/utils/proper_name.rb
@@ -31,12 +31,6 @@ module Utils
         end
       end
 
-      (0..components_without_conjunctions.length-3).each do |index|
-        if parameterized_components[index].length >1 && parameterized_components[index].last != "*"
-          parameterized_components[index] = abbrev_expr(parameterized_components[index])
-        end
-      end
-
       "^#{ parameterized_components.join("-").gsub(/-\(-/, "(-") }$"
     end
 


### PR DESCRIPTION
This PR:

* Removes a piece of code which fails to generate a regular expression to search people by slug including abbreviations. There are no expected mixed abbreviated names and full names (like María José and M. J. for the same person)
* Recovers the identification of names ignoring conjunctions like "i" and "e". The search is made using the proper regular expression of slug for the name