### PR TITLE
Remove gobierto budgets data dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,6 @@ source "https://rubygems.org"
 
 git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
 
-gem "gobierto_budgets_data", git: "https://github.com/PopulateTools/gobierto_budgets_data.git"
 gem "nokogiri"
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,145 +1,19 @@
-GIT
-  remote: https://github.com/PopulateTools/gobierto_budgets_data.git
-  revision: 2472cf1e64d136f74754187563c4e01b31c82dad
-  specs:
-    gobierto_budgets_data (0.1.0)
-      actionpack
-      activesupport
-      aws-sdk-s3
-      elasticsearch (~> 6.0, >= 6.0.2)
-      elasticsearch-extensions (~> 0.0.27)
-      ine-places (~> 0.3.0)
-      oj (~> 3.6)
-      rake (~> 13.0)
-
 GEM
   remote: https://rubygems.org/
   specs:
-    actionpack (7.1.3.2)
-      actionview (= 7.1.3.2)
-      activesupport (= 7.1.3.2)
-      nokogiri (>= 1.8.5)
-      racc
-      rack (>= 2.2.4)
-      rack-session (>= 1.0.1)
-      rack-test (>= 0.6.3)
-      rails-dom-testing (~> 2.2)
-      rails-html-sanitizer (~> 1.6)
-    actionview (7.1.3.2)
-      activesupport (= 7.1.3.2)
-      builder (~> 3.1)
-      erubi (~> 1.11)
-      rails-dom-testing (~> 2.2)
-      rails-html-sanitizer (~> 1.6)
-    activesupport (7.1.3.2)
-      base64
-      bigdecimal
-      concurrent-ruby (~> 1.0, >= 1.0.2)
-      connection_pool (>= 2.2.5)
-      drb
-      i18n (>= 1.6, < 2)
-      minitest (>= 5.1)
-      mutex_m
-      tzinfo (~> 2.0)
-    ansi (1.5.0)
     ast (2.4.2)
-    aws-eventstream (1.2.0)
-    aws-partitions (1.777.0)
-    aws-sdk-core (3.174.0)
-      aws-eventstream (~> 1, >= 1.0.2)
-      aws-partitions (~> 1, >= 1.651.0)
-      aws-sigv4 (~> 1.5)
-      jmespath (~> 1, >= 1.6.1)
-    aws-sdk-kms (1.66.0)
-      aws-sdk-core (~> 3, >= 3.174.0)
-      aws-sigv4 (~> 1.1)
-    aws-sdk-s3 (1.123.1)
-      aws-sdk-core (~> 3, >= 3.174.0)
-      aws-sdk-kms (~> 1)
-      aws-sigv4 (~> 1.4)
-    aws-sigv4 (1.5.2)
-      aws-eventstream (~> 1, >= 1.0.2)
-    base64 (0.2.0)
-    bigdecimal (3.1.6)
-    builder (3.2.4)
     byebug (11.1.3)
-    concurrent-ruby (1.2.2)
-    connection_pool (2.4.1)
-    crass (1.0.6)
-    drb (2.2.0)
-      ruby2_keywords
-    elasticsearch (6.8.3)
-      elasticsearch-api (= 6.8.3)
-      elasticsearch-transport (= 6.8.3)
-    elasticsearch-api (6.8.3)
-      multi_json
-    elasticsearch-extensions (0.0.33)
-      ansi
-      elasticsearch
-    elasticsearch-transport (6.8.3)
-      faraday (~> 1)
-      multi_json
-    erubi (1.12.0)
-    faraday (1.10.3)
-      faraday-em_http (~> 1.0)
-      faraday-em_synchrony (~> 1.0)
-      faraday-excon (~> 1.1)
-      faraday-httpclient (~> 1.0)
-      faraday-multipart (~> 1.0)
-      faraday-net_http (~> 1.0)
-      faraday-net_http_persistent (~> 1.0)
-      faraday-patron (~> 1.0)
-      faraday-rack (~> 1.0)
-      faraday-retry (~> 1.0)
-      ruby2_keywords (>= 0.0.4)
-    faraday-em_http (1.0.0)
-    faraday-em_synchrony (1.0.0)
-    faraday-excon (1.1.0)
-    faraday-httpclient (1.0.1)
-    faraday-multipart (1.0.4)
-      multipart-post (~> 2)
-    faraday-net_http (1.0.1)
-    faraday-net_http_persistent (1.2.0)
-    faraday-patron (1.0.0)
-    faraday-rack (1.0.0)
-    faraday-retry (1.0.3)
-    i18n (1.14.1)
-      concurrent-ruby (~> 1.0)
-    ine-places (0.3.0)
-      activesupport (>= 4.2)
-    jmespath (1.6.2)
     json (2.6.3)
-    loofah (2.21.3)
-      crass (~> 1.0.2)
-      nokogiri (>= 1.12.0)
     mini_portile2 (2.8.5)
-    minitest (5.19.0)
-    multi_json (1.15.0)
-    multipart-post (2.3.0)
-    mutex_m (0.2.0)
     nokogiri (1.16.2)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
-    oj (3.15.0)
     parallel (1.23.0)
     parser (3.2.2.3)
       ast (~> 2.4.1)
       racc
     racc (1.7.3)
-    rack (3.0.9.1)
-    rack-session (2.0.0)
-      rack (>= 3.0.0)
-    rack-test (2.1.0)
-      rack (>= 1.3)
-    rails-dom-testing (2.2.0)
-      activesupport (>= 5.0.0)
-      minitest
-      nokogiri (>= 1.6)
-    rails-html-sanitizer (1.6.0)
-      loofah (~> 2.21)
-      nokogiri (~> 1.14)
     rainbow (3.1.1)
-    rake (13.0.6)
     regexp_parser (2.8.1)
     rexml (3.2.5)
     rubocop (1.52.0)
@@ -155,9 +29,6 @@ GEM
     rubocop-ast (1.29.0)
       parser (>= 3.2.1.0)
     ruby-progressbar (1.13.0)
-    ruby2_keywords (0.0.5)
-    tzinfo (2.0.6)
-      concurrent-ruby (~> 1.0)
     unicode-display_width (2.4.2)
 
 PLATFORMS
@@ -165,7 +36,6 @@ PLATFORMS
 
 DEPENDENCIES
   byebug
-  gobierto_budgets_data!
   nokogiri
   rubocop
 

--- a/README.md
+++ b/README.md
@@ -6,8 +6,6 @@ ETL scripts for GenCat import of events, gifts, invitations and trips
 
 Edit `.env.example` and copy it to `.env` or `.rbenv-vars` with the expected values.
 
-This repository relies heavily in [gobierto_budgets_data](https://github.com/PopulateTools/gobierto_budgets_data)
-
 ## Available operations
 
 - check-data-presence


### PR DESCRIPTION
This PR removes the dependency on budgets data gem, since the Gencat ETL doesn't import any budget info.