### PR TITLE
Avoid exceptions if location is blank in row_decorator and return nil

### DIFF
--- a/utils/row_decorator.rb
+++ b/utils/row_decorator.rb
@@ -55,6 +55,8 @@ module Utils
     LOCALITY_TYPES = %w(political locality).freeze
 
     def geocoder_single_search(name, locality_postfix = nil)
+      return if name.blank?
+
       name = "#{ name }, #{ locality_postfix }" if locality_postfix
       GobiertoCommon::Location.search(name)
     end


### PR DESCRIPTION
This PR prevents sending `nil` to `GobiertoCommon::Location.search` method